### PR TITLE
Bugfix: Keys in value lists cause generation to fail

### DIFF
--- a/src/Permutation.php
+++ b/src/Permutation.php
@@ -4,14 +4,20 @@ namespace Portavice\Permutation;
 
 class Permutation
 {
+    private array $input;
     private array $result;
     private int $offset;
     private int $limit;
     private mixed $callback = null;
     private bool $unsetAfterCall = false;
     private ?array $callbackArgs;
-    public function __construct(private array $input, int $offset = 0, int $limit = 0)
+    public function __construct(array $input, int $offset = 0, int $limit = 0)
     {
+        $this->input = array_map(
+            fn ($valueList) => (is_array($valueList) ? array_values($valueList) : $valueList),
+            $input
+        );
+
         $this->result = [];
         $this->offset = $offset;
         $this->limit = $limit;

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -71,6 +71,34 @@ class Test extends TestCase
         ], $this->callBackOutput);
     }
 
+    public function testManualIndices(): void
+    {
+        $result = Permutation::getPermutations([
+            'first' => [
+                0 => 'a',
+                2 => 'b',
+                3 => 'c',
+            ],
+            'second' => [
+                'x',
+                1 => 'y',
+                'test' => 'z',
+            ],
+        ]);
+
+        static::assertEquals([
+            ['first' => 'a', 'second' => 'x'],
+            ['first' => 'b', 'second' => 'x'],
+            ['first' => 'c', 'second' => 'x'],
+            ['first' => 'a', 'second' => 'y'],
+            ['first' => 'b', 'second' => 'y'],
+            ['first' => 'c', 'second' => 'y'],
+            ['first' => 'a', 'second' => 'z'],
+            ['first' => 'b', 'second' => 'z'],
+            ['first' => 'c', 'second' => 'z'],
+        ], $result);
+    }
+
     final public function permutationOutPutReturn(array $permutation): void
     {
         $this->callBackOutput[] = $permutation;


### PR DESCRIPTION
If the input has keys in the value lists, the generation will fail. Or, if there are manual numerical keys with gaps, the generator will create entries with null values.

I fixed this quick and dirty by mapping each item of the input array to array_values(), if the input is an array.
This will of course fail, if the values are nested.