### PR TITLE
Feature: Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ $permutations = Permutation::getPermutationsRecursive(
 //     ['a' => 'a2', 'b' => 'b2', 'c' => 'c1'],
 //     ['a' => 'a2', 'b' => 'b2', 'c' => 'c2'],
 // ]
+
+// NEW: Generators! For memory constrained environments.
+// More info how to use generators here: https://www.php.net/manual/en/language.generators.overview.php
+$permutations = Permutation::getGenerator([
+    'a' => ['a1', 'a2'],
+    'b' => ['b1', 'b2'],
+    'c' => ['c1', 'c2'],
+]);
+
+foreach ($permutations as $permutation) {
+    // ... do stuff here!
+}
 ```
 
 ## License

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Portavice\Permutation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Portavice\Permutation\Permutation;
+
+class GeneratorTest extends TestCase
+{
+    public function testPermutationGeneratorFunction()
+    {
+        $input = [
+            'first' => ['a', 'b'],
+            'second' => ['w', 'v'],
+            'third' => ['y', 'z'],
+        ];
+
+        $iterator = Permutation::getGenerator($input);
+
+        $results = [];
+        foreach ($iterator as $value) {
+            $results[] = $value;
+        }
+
+        static::assertEquals([
+            ['first' => 'a', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'z'],
+        ], $results);
+    }
+
+    public function testPermutationGeneratorWithCallback()
+    {
+        $input = [
+            'first' => ['a', 'b'],
+            'second' => ['w', 'v'],
+            'third' => ['y', 'z'],
+        ];
+
+        $results = [];
+        $callbackResults = [];
+
+        $iterator = Permutation::getGenerator($input, function ($permutation) use (&$callbackResults) {
+            static::assertIsArray($permutation);
+            $callbackResults[] = $permutation;
+        });
+
+        foreach ($iterator as $value) {
+            $results[] = $value;
+        }
+
+        static::assertEquals([
+            ['first' => 'a', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'z'],
+        ], $results);
+
+        static::assertEquals([
+            ['first' => 'a', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'z'],
+        ], $callbackResults);
+    }
+
+    public function testPermutationGeneratorRecursive()
+    {
+        $input = [
+            'first' => ['a', 'b'],
+            'second' => ['w', 'v'],
+            'third' => ['y', 'z'],
+        ];
+
+        $results = [];
+
+        $iterator = Permutation::getRecursiveGenerator($input);
+
+        foreach ($iterator as $value) {
+            $results[] = $value;
+        }
+
+        $expectedPermutations = [
+            ['first' => 'a'],
+            ['first' => 'b'],
+            ['second' => 'w'],
+            ['second' => 'v'],
+            ['third' => 'y'],
+            ['third' => 'z'],
+            ['first' => 'a', 'second' => 'w'],
+            ['first' => 'a', 'second' => 'v'],
+            ['first' => 'a', 'third' => 'y'],
+            ['first' => 'a', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'w'],
+            ['first' => 'b', 'second' => 'v'],
+            ['first' => 'b', 'third' => 'y'],
+            ['first' => 'b', 'third' => 'z'],
+            ['second' => 'w', 'third' => 'y'],
+            ['second' => 'v', 'third' => 'y'],
+            ['second' => 'w', 'third' => 'z'],
+            ['second' => 'v', 'third' => 'z'],
+            ['first' => 'a', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'y'],
+            ['first' => 'a', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'w', 'third' => 'z'],
+            ['first' => 'a', 'second' => 'v', 'third' => 'z'],
+            ['first' => 'b', 'second' => 'v', 'third' => 'z'],
+        ];
+
+        static::assertCount(count($expectedPermutations), $results);
+        foreach ($expectedPermutations as $permutation) {
+            static::assertContains($permutation, $results);
+        }
+    }
+}


### PR DESCRIPTION
I added generators to the Permutation class, so we can save memory if we only want to iterate over the generated permutations.

I am unhappy with the implementation for the `recursiveGenerator()` method, as it doesn't return the values in the same order as the regular `permutateRecursive()` method.